### PR TITLE
fix(android): Parent view steals map pan gesture

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0
@@ -110,10 +110,10 @@ jobs:
           JAVA_OPTS: '-XX:MaxHeapSize=6g'
         run: yarn build:android
   build-ios:
-    runs-on: macos-latest
+    runs-on: macos-26
     needs: [lint, test, docs]
     env:
-      XCODE_VERSION: '26.0.1'
+      XCODE_VERSION: '26.2'
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,8 +8,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
+      - name: Lint commit messages
+        run: |
+          yarn commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
   lint:
     runs-on: macos-26
+    needs: [commitlint]
     steps:
       - name: Checkout
         uses: actions/checkout@v5.0.0

--- a/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
+++ b/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
@@ -813,6 +813,7 @@ class GoogleMapsViewImpl(
       if (destroyed) return@onUi
       destroyed = true
       lifecycleObserver?.toDestroyedState()
+      lifecycleObserver = null
       markerBuilder.cancelAllJobs()
       clearMarkers()
       clearPolylines()

--- a/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
+++ b/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
@@ -10,7 +10,9 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.location.Location
 import android.util.Size
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.findViewTreeLifecycleOwner
@@ -180,6 +182,30 @@ class GoogleMapsViewImpl(
           }
         }
     }
+
+  private fun disallowParentTouchEventIntercept(disallowIntercept: Boolean): Boolean {
+    val parent = this.parent as? ViewGroup
+    if (parent != null) {
+        parent.requestDisallowInterceptTouchEvent(disallowIntercept)
+        return true
+    }
+    return false
+  }
+
+  override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+    when (ev.actionMasked) {
+        MotionEvent.ACTION_DOWN -> {
+            disallowParentTouchEventIntercept(
+                googleMap?.uiSettings?.isScrollGesturesEnabled ?: false
+            )
+        }
+        MotionEvent.ACTION_UP -> {
+            disallowParentTouchEventIntercept(false)
+        }
+    }
+    super.dispatchTouchEvent(ev)
+    return true
+  }
 
   override fun onCameraMoveStarted(reason: Int) =
     onUi {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "source": "src/index",
   "react-native": "src/index",
   "scripts": {
+    "commitlint": "commitlint",
     "typecheck:lib": "tsc --noEmit -p tsconfig.json",
     "typecheck:example": "tsc --noEmit -p example/tsconfig.json",
     "typecheck": "yarn typecheck:lib && yarn typecheck:example",


### PR DESCRIPTION
## Pull request

Please ensure this PR targets the **`dev` branch** and follows the project conventions.
CI already runs linting, formatting, and build checks automatically.

---

### Before submitting

- [x] This PR targets the `dev` branch (not `main`)
- [x] Commit messages follow the semantic-release format
- [x] No debug logs or sensitive data included

---

### Summary

This fixes an issue where parent PagerView (and ScrollView?) steals MapView's pan gesture.

---

### Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Internal / CI
- [ ] Documentation

---

### Scope

- [x] Android
- [ ] iOS
- [ ] JS
- [ ] Example App
- [ ] Docs

---

### Related

List any related issues, pull requests, or discussions.
Use the format:
`Fixes #123`, `Refs #456`, `Close #789`

---

### Additional notes

If you have a map inside a PagerView (and ScrollView?) with touch events enabled, they override MapView's pan gesture. The expected behaviour is to be able to pan the map normally. This is the current behaviour on iOS.
