### PR TITLE
fix: prevent stale markers from async icon rendering

### DIFF
--- a/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
+++ b/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
@@ -20,6 +20,7 @@ import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.MapView
 import com.google.android.gms.maps.MapsInitializer
+import com.google.android.gms.maps.model.BitmapDescriptor
 import com.google.android.gms.maps.model.CameraPosition
 import com.google.android.gms.maps.model.Circle
 import com.google.android.gms.maps.model.CircleOptions
@@ -91,7 +92,7 @@ class GoogleMapsViewImpl(
   private var googleMap: GoogleMap? = null
   private var mapView: MapView? = null
 
-  private val pendingMarkers = mutableListOf<Triple<String, MarkerOptions, MarkerTag>>()
+  private val pendingMarkers = linkedMapOf<String, PendingMarker>()
   private val pendingPolylines = mutableListOf<Pair<String, PolylineOptions>>()
   private val pendingPolygons = mutableListOf<Pair<String, PolygonOptions>>()
   private val pendingCircles = mutableListOf<Pair<String, CircleOptions>>()
@@ -247,7 +248,13 @@ class GoogleMapsViewImpl(
     locationConfig = locationConfig
 
     if (pendingMarkers.isNotEmpty()) {
-      pendingMarkers.forEach { (id, opts, markerTag) -> addMarkerInternal(id, opts, markerTag) }
+      pendingMarkers.forEach { (id, pending) ->
+        addMarkerInternal(
+          id,
+          markerBuilder.build(pending.marker, pending.icon),
+          MarkerTag(id = id, iconSvg = pending.marker.infoWindowIconSvg),
+        )
+      }
       pendingMarkers.clear()
     }
     if (pendingPolylines.isNotEmpty()) {
@@ -514,18 +521,41 @@ class GoogleMapsViewImpl(
     return promise
   }
 
-  fun addMarker(
-    id: String,
-    opts: MarkerOptions,
-    markerTag: MarkerTag,
+  fun completeMarkerBuild(
+    marker: RNMarker,
+    icon: BitmapDescriptor?,
+    isCurrent: () -> Boolean,
   ) = onUi {
-    if (googleMap == null) {
-      pendingMarkers.add(Triple(id, opts, markerTag))
+    if (!isCurrent()) return@onUi
+
+    val id = marker.id
+    val pending = pendingMarkers.remove(id)
+    val latestMarker = pending?.marker ?: marker
+    val currentMarker = markersById[id]
+
+    if (currentMarker != null) {
+      markerBuilder.updateIcon(currentMarker, icon)
       return@onUi
     }
 
-    markersById.remove(id)?.remove()
-    addMarkerInternal(id, opts, markerTag)
+    if (googleMap == null) {
+      pendingMarkers[id] = PendingMarker(marker = latestMarker, icon = icon)
+      return@onUi
+    }
+
+    addMarkerInternal(
+      id,
+      markerBuilder.build(latestMarker, icon),
+      MarkerTag(id = id, iconSvg = latestMarker.infoWindowIconSvg),
+    )
+  }
+
+  fun updatePendingMarker(
+    id: String,
+    marker: RNMarker,
+  ) = onUi {
+    val pending = pendingMarkers[id] ?: return@onUi
+    pendingMarkers[id] = pending.copy(marker = marker)
   }
 
   private fun addMarkerInternal(
@@ -557,6 +587,7 @@ class GoogleMapsViewImpl(
 
   fun removeMarker(id: String) =
     onUi {
+      pendingMarkers.remove(id)
       markersById.remove(id)?.remove()
     }
 

--- a/android/src/main/java/com/rngooglemapsplus/MapMarkerBuilder.kt
+++ b/android/src/main/java/com/rngooglemapsplus/MapMarkerBuilder.kt
@@ -24,7 +24,6 @@ import com.rngooglemapsplus.extensions.anchorEquals
 import com.rngooglemapsplus.extensions.coordinatesEquals
 import com.rngooglemapsplus.extensions.infoWindowAnchorEquals
 import com.rngooglemapsplus.extensions.markerInfoWindowStyleEquals
-import com.rngooglemapsplus.extensions.markerStyleEquals
 import com.rngooglemapsplus.extensions.styleHash
 import com.rngooglemapsplus.extensions.toLatLng
 import kotlinx.coroutines.CoroutineScope
@@ -188,35 +187,17 @@ class MapMarkerBuilder(
       marker.position = next.coordinate.toLatLng()
     }
 
-    if (!prev.markerStyleEquals(next)) {
-      buildIconAsync(next) { icon ->
-        marker.setIcon(icon)
-        if (!prev.anchorEquals(next)) {
-          marker.setAnchor(
-            (next.anchor?.x ?: 0.5f).toFloat(),
-            (next.anchor?.y ?: 1.0f).toFloat(),
-          )
-        }
-        if (!prev.infoWindowAnchorEquals(next)) {
-          marker.setInfoWindowAnchor(
-            (next.infoWindowAnchor?.x ?: 0.5f).toFloat(),
-            (next.infoWindowAnchor?.y ?: 0f).toFloat(),
-          )
-        }
-      }
-    } else {
-      if (!prev.anchorEquals(next)) {
-        marker.setAnchor(
-          (next.anchor?.x ?: 0.5f).toFloat(),
-          (next.anchor?.y ?: 1.0f).toFloat(),
-        )
-      }
-      if (!prev.infoWindowAnchorEquals(next)) {
-        marker.setInfoWindowAnchor(
-          (next.infoWindowAnchor?.x ?: 0.5f).toFloat(),
-          (next.infoWindowAnchor?.y ?: 0f).toFloat(),
-        )
-      }
+    if (!prev.anchorEquals(next)) {
+      marker.setAnchor(
+        (next.anchor?.x ?: 0.5f).toFloat(),
+        (next.anchor?.y ?: 1.0f).toFloat(),
+      )
+    }
+    if (!prev.infoWindowAnchorEquals(next)) {
+      marker.setInfoWindowAnchor(
+        (next.infoWindowAnchor?.x ?: 0.5f).toFloat(),
+        (next.infoWindowAnchor?.y ?: 0f).toFloat(),
+      )
     }
 
     if (prev.title != next.title) {
@@ -250,6 +231,13 @@ class MapMarkerBuilder(
     if (!prev.markerInfoWindowStyleEquals(next)) {
       marker.tag = MarkerTag(id = next.id, iconSvg = next.infoWindowIconSvg)
     }
+  }
+
+  fun updateIcon(
+    marker: Marker,
+    icon: BitmapDescriptor?,
+  ) = onUi {
+    marker.setIcon(icon)
   }
 
   fun buildIconAsync(

--- a/android/src/main/java/com/rngooglemapsplus/MapMarkerBuilder.kt
+++ b/android/src/main/java/com/rngooglemapsplus/MapMarkerBuilder.kt
@@ -27,6 +27,7 @@ import com.rngooglemapsplus.extensions.markerInfoWindowStyleEquals
 import com.rngooglemapsplus.extensions.styleHash
 import com.rngooglemapsplus.extensions.toLatLng
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -244,26 +245,29 @@ class MapMarkerBuilder(
     m: RNMarker,
     onReady: (BitmapDescriptor?) -> Unit,
   ) {
-    cancelIconJob(m.id)
-
-    m.iconSvg ?: return onReady(null)
+    val iconSvg = m.iconSvg
+    if (iconSvg == null) {
+      completeIconBuild(m.id, null, onReady)
+      return
+    }
 
     val key = m.styleHash()
     iconCache.get(key)?.let { cached ->
-      onReady(cached)
+      completeIconBuild(m.id, cached, onReady)
       return
     }
 
     val job =
-      scope.launch {
+      scope.launch(start = CoroutineStart.LAZY) {
+        val currentJob = checkNotNull(currentCoroutineContext()[Job])
+
         try {
           ensureActive()
-          val renderResult = renderBitmap(m.iconSvg, m.id)
+          val renderResult = renderBitmap(iconSvg, m.id)
 
           if (renderResult?.bitmap == null) {
             withContext(Dispatchers.Main) {
               ensureActive()
-              jobsById.remove(m.id)
               onReady(createFallbackDescriptor())
             }
             return@launch
@@ -279,7 +283,6 @@ class MapMarkerBuilder(
 
           withContext(Dispatchers.Main) {
             ensureActive()
-            jobsById.remove(m.id)
             onReady(desc)
           }
         } catch (e: OutOfMemoryError) {
@@ -287,7 +290,6 @@ class MapMarkerBuilder(
           clearIconCache()
           withContext(Dispatchers.Main) {
             ensureActive()
-            jobsById.remove(m.id)
             onReady(createFallbackDescriptor())
           }
         } catch (_: CancellationException) {
@@ -296,28 +298,50 @@ class MapMarkerBuilder(
           mapErrorHandler.report(RNMapErrorCode.MARKER_ICON_BUILD_FAILED, "markerId=${m.id} buildIconAsync failed", t)
           withContext(Dispatchers.Main) {
             ensureActive()
-            jobsById.remove(m.id)
             onReady(createFallbackDescriptor())
           }
+        } finally {
+          jobsById.remove(m.id, currentJob)
         }
       }
 
-    jobsById[m.id] = job
+    jobsById.put(m.id, job)?.cancel()
+    job.start()
+  }
+
+  private fun completeIconBuild(
+    id: String,
+    icon: BitmapDescriptor?,
+    onReady: (BitmapDescriptor?) -> Unit,
+  ) {
+    val activeJob = Job()
+    jobsById.put(id, activeJob)?.cancel()
+
+    onUi {
+      try {
+        if (jobsById[id] === activeJob && activeJob.isActive) {
+          onReady(icon)
+        }
+      } finally {
+        jobsById.remove(id, activeJob)
+        activeJob.complete()
+      }
+    }
   }
 
   fun hasIconJob(id: String): Boolean = jobsById.containsKey(id)
 
   fun cancelIconJob(id: String) {
-    jobsById[id]?.cancel()
-    jobsById.remove(id)
+    jobsById.remove(id)?.cancel()
   }
 
   fun cancelAllJobs() {
-    val ids = jobsById.keys.toList()
-    ids.forEach { id ->
-      jobsById[id]?.cancel()
+    val activeJobs = jobsById.entries.map { it.key to it.value }
+    activeJobs.forEach { (id, job) ->
+      if (jobsById.remove(id, job)) {
+        job.cancel()
+      }
     }
-    jobsById.clear()
     clearIconCache()
   }
 

--- a/android/src/main/java/com/rngooglemapsplus/PendingMarker.kt
+++ b/android/src/main/java/com/rngooglemapsplus/PendingMarker.kt
@@ -1,0 +1,8 @@
+package com.rngooglemapsplus
+
+import com.google.android.gms.maps.model.BitmapDescriptor
+
+internal data class PendingMarker(
+  val marker: RNMarker,
+  val icon: BitmapDescriptor?,
+)

--- a/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
+++ b/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
@@ -9,6 +9,7 @@ import com.margelo.nitro.core.Promise
 import com.rngooglemapsplus.extensions.circleEquals
 import com.rngooglemapsplus.extensions.isFileResult
 import com.rngooglemapsplus.extensions.markerEquals
+import com.rngooglemapsplus.extensions.markerStyleEquals
 import com.rngooglemapsplus.extensions.polygonEquals
 import com.rngooglemapsplus.extensions.polylineEquals
 import com.rngooglemapsplus.extensions.toCameraPosition
@@ -32,6 +33,7 @@ class RNGoogleMapsPlusView(
   private val playServiceHandler = PlayServicesHandler(context)
 
   private val markerBuilder = MapMarkerBuilder(context, mapErrorHandler)
+  private val markerBuildTokens = java.util.concurrent.ConcurrentHashMap<String, Any>()
   private val polylineBuilder = MapPolylineBuilder()
   private val polygonBuilder = MapPolygonBuilder()
   private val circleBuilder = MapCircleBuilder()
@@ -149,6 +151,7 @@ class RNGoogleMapsPlusView(
       field = value
 
       (prevById.keys - nextById.keys).forEach { id ->
+        invalidateMarkerBuild(id)
         markerBuilder.cancelIconJob(id)
         view.removeMarker(id)
       }
@@ -157,7 +160,9 @@ class RNGoogleMapsPlusView(
         val prev = prevById[id]
         when {
           prev == null -> {
+            val buildToken = nextMarkerBuildToken(id)
             markerBuilder.buildIconAsync(next) { icon ->
+              if (!isCurrentMarkerBuild(id, buildToken)) return@buildIconAsync
               view.addMarker(
                 id,
                 markerBuilder.build(next, icon),
@@ -171,7 +176,9 @@ class RNGoogleMapsPlusView(
 
           !prev.markerEquals(next) -> {
             if (markerBuilder.hasIconJob(id)) {
+              val buildToken = nextMarkerBuildToken(id)
               markerBuilder.buildIconAsync(next) { icon ->
+                if (!isCurrentMarkerBuild(id, buildToken)) return@buildIconAsync
                 view.addMarker(
                   id,
                   markerBuilder.build(next, icon),
@@ -182,11 +189,33 @@ class RNGoogleMapsPlusView(
               view.updateMarker(id) { marker ->
                 markerBuilder.update(prev, next, marker)
               }
+
+              if (!prev.markerStyleEquals(next)) {
+                val buildToken = nextMarkerBuildToken(id)
+                markerBuilder.buildIconAsync(next) { icon ->
+                  view.updateMarker(id) { marker ->
+                    if (isCurrentMarkerBuild(id, buildToken)) {
+                      markerBuilder.updateIcon(marker, icon)
+                    }
+                  }
+                }
+              }
             }
           }
         }
       }
     }
+
+  private fun nextMarkerBuildToken(id: String): Any = Any().also { markerBuildTokens[id] = it }
+
+  private fun invalidateMarkerBuild(id: String) {
+    markerBuildTokens.remove(id)
+  }
+
+  private fun isCurrentMarkerBuild(
+    id: String,
+    token: Any,
+  ): Boolean = markerBuildTokens[id] === token
 
   override var polylines: Array<RNPolyline>? = null
     set(value) {

--- a/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
+++ b/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
@@ -1,6 +1,5 @@
 package com.rngooglemapsplus
 
-import MarkerTag
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.uimanager.ThemedReactContext
 import com.google.android.gms.maps.GoogleMapOptions
@@ -44,6 +43,7 @@ class RNGoogleMapsPlusView(
     GoogleMapsViewImpl(context, locationHandler, playServiceHandler, markerBuilder, mapErrorHandler)
 
   override fun onDropView() {
+    markerBuildTokens.clear()
     view.destroyInternal()
   }
 
@@ -162,42 +162,25 @@ class RNGoogleMapsPlusView(
           prev == null -> {
             val buildToken = nextMarkerBuildToken(id)
             markerBuilder.buildIconAsync(next) { icon ->
-              if (!isCurrentMarkerBuild(id, buildToken)) return@buildIconAsync
-              view.addMarker(
-                id,
-                markerBuilder.build(next, icon),
-                MarkerTag(
-                  id = id,
-                  iconSvg = next.infoWindowIconSvg,
-                ),
-              )
+              view.completeMarkerBuild(next, icon) {
+                isCurrentMarkerBuild(id, buildToken)
+              }
             }
           }
 
           !prev.markerEquals(next) -> {
-            if (markerBuilder.hasIconJob(id)) {
+            val hasIconJob = markerBuilder.hasIconJob(id)
+
+            view.updateMarker(id) { marker ->
+              markerBuilder.update(prev, next, marker)
+            }
+            view.updatePendingMarker(id, next)
+
+            if (hasIconJob || !prev.markerStyleEquals(next)) {
               val buildToken = nextMarkerBuildToken(id)
               markerBuilder.buildIconAsync(next) { icon ->
-                if (!isCurrentMarkerBuild(id, buildToken)) return@buildIconAsync
-                view.addMarker(
-                  id,
-                  markerBuilder.build(next, icon),
-                  MarkerTag(id = id, iconSvg = next.infoWindowIconSvg),
-                )
-              }
-            } else {
-              view.updateMarker(id) { marker ->
-                markerBuilder.update(prev, next, marker)
-              }
-
-              if (!prev.markerStyleEquals(next)) {
-                val buildToken = nextMarkerBuildToken(id)
-                markerBuilder.buildIconAsync(next) { icon ->
-                  view.updateMarker(id) { marker ->
-                    if (isCurrentMarkerBuild(id, buildToken)) {
-                      markerBuilder.updateIcon(marker, icon)
-                    }
-                  }
+                view.completeMarkerBuild(next, icon) {
+                  isCurrentMarkerBuild(id, buildToken)
                 }
               }
             }

--- a/ios/GoogleMapViewImpl.swift
+++ b/ios/GoogleMapViewImpl.swift
@@ -15,7 +15,7 @@ GMSIndoorDisplayDelegate {
   private var mapViewLoaded = false
   private var deInitialized = false
 
-  private var pendingMarkers: [(id: String, marker: GMSMarker)] = []
+  private var pendingMarkers: [String: (marker: RNMarker, icon: UIImage?)] = [:]
   private var pendingPolylines: [(id: String, polyline: GMSPolyline)] = []
   private var pendingPolygons: [(id: String, polygon: GMSPolygon)] = []
   private var pendingCircles: [(id: String, circle: GMSCircle)] = []
@@ -143,7 +143,12 @@ GMSIndoorDisplayDelegate {
     ({ self.locationConfig = self.locationConfig })()
 
     if !pendingMarkers.isEmpty {
-      pendingMarkers.forEach { addMarkerInternal(id: $0.id, marker: $0.marker) }
+      pendingMarkers.forEach { id, pending in
+        addMarkerInternal(
+          id: id,
+          marker: markerBuilder.build(pending.marker, icon: pending.icon)
+        )
+      }
       pendingMarkers.removeAll()
     }
     if !pendingPolylines.isEmpty {
@@ -482,14 +487,39 @@ GMSIndoorDisplayDelegate {
     return promise
   }
 
-  func addMarker(id: String, marker: GMSMarker) {
+  func completeMarkerBuild(
+    _ marker: RNMarker,
+    icon: UIImage?,
+    isCurrent: @escaping () -> Bool
+  ) {
     onMain {
-      if self.mapView == nil {
-        self.pendingMarkers.append((id, marker))
+      guard isCurrent() else { return }
+
+      let id = marker.id
+      let pending = self.pendingMarkers.removeValue(forKey: id)
+      let latestMarker = pending?.marker ?? marker
+
+      if let currentMarker = self.markersById[id] {
+        self.markerBuilder.updateIcon(currentMarker, icon: icon)
         return
       }
-      self.markersById.removeValue(forKey: id).map { $0.map = nil }
-      self.addMarkerInternal(id: id, marker: marker)
+
+      if self.mapView == nil {
+        self.pendingMarkers[id] = (marker: latestMarker, icon: icon)
+        return
+      }
+
+      self.addMarkerInternal(
+        id: id,
+        marker: self.markerBuilder.build(latestMarker, icon: icon)
+      )
+    }
+  }
+
+  func updatePendingMarker(id: String, marker: RNMarker) {
+    onMain {
+      guard let pending = self.pendingMarkers[id] else { return }
+      self.pendingMarkers[id] = (marker: marker, icon: pending.icon)
     }
   }
 
@@ -514,6 +544,7 @@ GMSIndoorDisplayDelegate {
 
   func removeMarker(id: String) {
     onMain {
+      self.pendingMarkers.removeValue(forKey: id)
       self.markersById.removeValue(forKey: id).map {
         $0.icon = nil
         $0.map = nil

--- a/ios/MapMarkerBuilder.swift
+++ b/ios/MapMarkerBuilder.swift
@@ -10,7 +10,8 @@ final class MapMarkerBuilder {
     c.countLimit = 256
     return c
   }()
-  private var tasks: [String: Task<Void, Never>] = [:]
+  private let tasksLock = NSLock()
+  private var tasks: [String: MarkerBuildToken] = [:]
 
   init(mapErrorHandler: MapErrorHandler) {
     self.mapErrorHandler = mapErrorHandler
@@ -136,23 +137,38 @@ final class MapMarkerBuilder {
     _ m: RNMarker,
     onReady: @escaping (UIImage?) -> Void
   ) {
-    cancelIconTask(m.id)
+    let activeTask = MarkerBuildToken()
+    setActiveTask(activeTask, id: m.id)
 
     guard let iconSvg = m.iconSvg else {
-      onReady(nil)
+      onMain { [weak self] in
+        self?.finishIconBuild(
+          m.id,
+          activeTask: activeTask,
+          icon: nil,
+          onReady: onReady
+        )
+      }
       return
     }
 
     let key = m.styleHash()
     if let cached = iconCache.object(forKey: key) {
-      onReady(cached)
+      onMain { [weak self] in
+        self?.finishIconBuild(
+          m.id,
+          activeTask: activeTask,
+          icon: cached,
+          onReady: onReady
+        )
+      }
       return
     }
 
     let scale = UIScreen.main.scale
 
-    let task = Task(priority: .userInitiated) { [weak self] in
-      guard let self else { return }
+    let task = Task(priority: .userInitiated) { [weak self, weak activeTask] in
+      guard let self, let activeTask else { return }
 
       let renderResult = self.renderUIImage(iconSvg, m.id, scale)
       guard !Task.isCancelled else { return }
@@ -160,8 +176,12 @@ final class MapMarkerBuilder {
       guard let renderResult = renderResult else {
         await MainActor.run {
           guard !Task.isCancelled else { return }
-          self.tasks.removeValue(forKey: m.id)
-          onReady(self.createFallbackUIImage())
+          self.finishIconBuild(
+            m.id,
+            activeTask: activeTask,
+            icon: self.createFallbackUIImage(),
+            onReady: onReady
+          )
         }
         return
       }
@@ -172,31 +192,70 @@ final class MapMarkerBuilder {
 
       await MainActor.run {
         guard !Task.isCancelled else { return }
-        self.tasks.removeValue(forKey: m.id)
-        onReady(renderResult.image)
+        self.finishIconBuild(
+          m.id,
+          activeTask: activeTask,
+          icon: renderResult.image,
+          onReady: onReady
+        )
       }
     }
+    activeTask.setTask(task)
+  }
 
-    tasks[m.id] = task
+  private func finishIconBuild(
+    _ id: String,
+    activeTask: MarkerBuildToken,
+    icon: UIImage?,
+    onReady: @escaping (UIImage?) -> Void
+  ) {
+    guard isActiveTask(activeTask, id: id) else { return }
+    onReady(icon)
+    removeActiveTask(activeTask, id: id)
   }
 
   func hasIconTask(_ id: String) -> Bool {
-    tasks[id] != nil
+    tasksLock.lock()
+    defer { tasksLock.unlock() }
+    return tasks[id] != nil
   }
 
   func cancelIconTask(_ id: String) {
-    tasks[id]?.cancel()
-    tasks.removeValue(forKey: id)
+    tasksLock.lock()
+    let activeTask = tasks.removeValue(forKey: id)
+    tasksLock.unlock()
+    activeTask?.cancel()
   }
 
   func cancelAllIconTasks() {
-    let ids = Array(tasks.keys)
-    for id in ids {
-      tasks[id]?.cancel()
-    }
+    tasksLock.lock()
+    let activeTasks = Array(tasks.values)
     tasks.removeAll()
+    tasksLock.unlock()
+    activeTasks.forEach { $0.cancel() }
     iconCache.removeAllObjects()
     CATransaction.flush()
+  }
+
+  private func setActiveTask(_ activeTask: MarkerBuildToken, id: String) {
+    tasksLock.lock()
+    let previousTask = tasks.updateValue(activeTask, forKey: id)
+    tasksLock.unlock()
+    previousTask?.cancel()
+  }
+
+  private func isActiveTask(_ activeTask: MarkerBuildToken, id: String) -> Bool {
+    tasksLock.lock()
+    defer { tasksLock.unlock() }
+    return tasks[id] === activeTask
+  }
+
+  private func removeActiveTask(_ activeTask: MarkerBuildToken, id: String) {
+    tasksLock.lock()
+    if tasks[id] === activeTask {
+      tasks.removeValue(forKey: id)
+    }
+    tasksLock.unlock()
   }
 
   func buildInfoWindow(markerTag: MarkerTag) -> UIImageView? {

--- a/ios/MapMarkerBuilder.swift
+++ b/ios/MapMarkerBuilder.swift
@@ -54,46 +54,24 @@ final class MapMarkerBuilder {
     onMain {
       withCATransaction(disableActions: true) {
 
-        var tracksViewChanges = false
         var tracksInfoWindowChanges = false
 
         if !prev.coordinateEquals(next) {
           m.position = next.coordinate.toCLLocationCoordinate2D()
         }
 
-        if !prev.markerStyleEquals(next) {
-          self.buildIconAsync(next) { img in
-            tracksViewChanges = true
-            m.icon = img
+        if !prev.anchorEquals(next) {
+          m.groundAnchor = CGPoint(
+            x: next.anchor?.x ?? 0.5,
+            y: next.anchor?.y ?? 1
+          )
+        }
 
-            if !prev.anchorEquals(next) {
-              m.groundAnchor = CGPoint(
-                x: next.anchor?.x ?? 0.5,
-                y: next.anchor?.y ?? 1
-              )
-            }
-
-            if !prev.infoWindowAnchorEquals(next) {
-              m.infoWindowAnchor = CGPoint(
-                x: next.infoWindowAnchor?.x ?? 0.5,
-                y: next.infoWindowAnchor?.y ?? 0
-              )
-            }
-          }
-        } else {
-          if !prev.anchorEquals(next) {
-            m.groundAnchor = CGPoint(
-              x: next.anchor?.x ?? 0.5,
-              y: next.anchor?.y ?? 1
-            )
-          }
-
-          if !prev.infoWindowAnchorEquals(next) {
-            m.infoWindowAnchor = CGPoint(
-              x: next.infoWindowAnchor?.x ?? 0.5,
-              y: next.infoWindowAnchor?.y ?? 0
-            )
-          }
+        if !prev.infoWindowAnchorEquals(next) {
+          m.infoWindowAnchor = CGPoint(
+            x: next.infoWindowAnchor?.x ?? 0.5,
+            y: next.infoWindowAnchor?.y ?? 0
+          )
         }
 
         if prev.title != next.title {
@@ -135,22 +113,21 @@ final class MapMarkerBuilder {
           )
         }
 
-        if tracksViewChanges {
-          m.tracksViewChanges = tracksViewChanges
-        }
         if tracksInfoWindowChanges {
           m.tracksInfoWindowChanges = tracksInfoWindowChanges
         }
 
-        if tracksViewChanges || tracksInfoWindowChanges {
-          if tracksViewChanges {
-            m.tracksViewChanges = false
-          }
-
-          if tracksInfoWindowChanges {
-            m.tracksInfoWindowChanges = false
-          }
+        if tracksInfoWindowChanges {
+          m.tracksInfoWindowChanges = false
         }
+      }
+    }
+  }
+
+  func updateIcon(_ marker: GMSMarker, icon: UIImage?) {
+    onMain {
+      withCATransaction(disableActions: true) {
+        marker.icon = icon
       }
     }
   }

--- a/ios/MarkerBuildToken.swift
+++ b/ios/MarkerBuildToken.swift
@@ -1,1 +1,30 @@
-final class MarkerBuildToken {}
+import Foundation
+
+final class MarkerBuildToken {
+  private let lock = NSLock()
+  private var task: Task<Void, Never>?
+  private var cancelled = false
+
+  func setTask(_ task: Task<Void, Never>) {
+    lock.lock()
+    let shouldCancel = cancelled
+    if !shouldCancel {
+      self.task = task
+    }
+    lock.unlock()
+
+    if shouldCancel {
+      task.cancel()
+    }
+  }
+
+  func cancel() {
+    lock.lock()
+    cancelled = true
+    let activeTask = task
+    task = nil
+    lock.unlock()
+
+    activeTask?.cancel()
+  }
+}

--- a/ios/MarkerBuildToken.swift
+++ b/ios/MarkerBuildToken.swift
@@ -1,0 +1,1 @@
+final class MarkerBuildToken {}

--- a/ios/RNGoogleMapsPlusView.swift
+++ b/ios/RNGoogleMapsPlusView.swift
@@ -57,6 +57,9 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
   }
 
   func onDropView() {
+    markerBuildTokenLock.lock()
+    markerBuildTokens.removeAll()
+    markerBuildTokenLock.unlock()
     impl.deinitInternal()
   }
 
@@ -150,27 +153,20 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
       for (id, next) in nextById {
         if let prev = prevById[id] {
           if !prev.markerEquals(next) {
-            if self.markerBuilder.hasIconTask(id) {
+            let hasIconTask = self.markerBuilder.hasIconTask(id)
+
+            self.impl.updateMarker(id: id) { [weak self] m in
+              guard let self else { return }
+              self.markerBuilder.update(prev, next, m)
+            }
+            self.impl.updatePendingMarker(id: id, marker: next)
+
+            if hasIconTask || !prev.markerStyleEquals(next) {
               let buildToken = self.nextMarkerBuildToken(id)
               self.markerBuilder.buildIconAsync(next) { [weak self] icon in
-                guard let self, self.isCurrentMarkerBuild(id, buildToken) else { return }
-                let marker = self.markerBuilder.build(next, icon: icon)
-                self.impl.addMarker(id: id, marker: marker)
-              }
-            } else {
-              self.impl.updateMarker(id: id) { [weak self] m in
                 guard let self else { return }
-                self.markerBuilder.update(prev, next, m)
-              }
-
-              if !prev.markerStyleEquals(next) {
-                let buildToken = self.nextMarkerBuildToken(id)
-                self.markerBuilder.buildIconAsync(next) { [weak self] icon in
-                  guard let self else { return }
-                  self.impl.updateMarker(id: id) { marker in
-                    guard self.isCurrentMarkerBuild(id, buildToken) else { return }
-                    self.markerBuilder.updateIcon(marker, icon: icon)
-                  }
+                self.impl.completeMarkerBuild(next, icon: icon) {
+                  self.isCurrentMarkerBuild(id, buildToken)
                 }
               }
             }
@@ -178,9 +174,10 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
         } else {
           let buildToken = self.nextMarkerBuildToken(id)
           self.markerBuilder.buildIconAsync(next) { [weak self] icon in
-            guard let self, self.isCurrentMarkerBuild(id, buildToken) else { return }
-            let marker = self.markerBuilder.build(next, icon: icon)
-            self.impl.addMarker(id: id, marker: marker)
+            guard let self else { return }
+            self.impl.completeMarkerBuild(next, icon: icon) {
+              self.isCurrentMarkerBuild(id, buildToken)
+            }
           }
         }
       }

--- a/ios/RNGoogleMapsPlusView.swift
+++ b/ios/RNGoogleMapsPlusView.swift
@@ -9,6 +9,8 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
   private let permissionHandler: PermissionHandler
   private let locationHandler: LocationHandler
   private let markerBuilder: MapMarkerBuilder
+  private let markerBuildTokenLock = NSLock()
+  private var markerBuildTokens: [String: MarkerBuildToken] = [:]
 
   private let polylineBuilder = MapPolylineBuilder()
   private let polygonBuilder = MapPolygonBuilder()
@@ -32,6 +34,26 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
       locationHandler: locationHandler,
       markerBuilder: markerBuilder
     )
+  }
+
+  private func nextMarkerBuildToken(_ id: String) -> MarkerBuildToken {
+    markerBuildTokenLock.lock()
+    defer { markerBuildTokenLock.unlock() }
+    let token = MarkerBuildToken()
+    markerBuildTokens[id] = token
+    return token
+  }
+
+  private func invalidateMarkerBuild(_ id: String) {
+    markerBuildTokenLock.lock()
+    defer { markerBuildTokenLock.unlock() }
+    markerBuildTokens.removeValue(forKey: id)
+  }
+
+  private func isCurrentMarkerBuild(_ id: String, _ token: MarkerBuildToken) -> Bool {
+    markerBuildTokenLock.lock()
+    defer { markerBuildTokenLock.unlock() }
+    return markerBuildTokens[id] === token
   }
 
   func onDropView() {
@@ -120,6 +142,7 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
       let removed = Set(prevById.keys).subtracting(nextById.keys)
 
       removed.forEach {
+        self.invalidateMarkerBuild($0)
         self.impl.removeMarker(id: $0)
         self.markerBuilder.cancelIconTask($0)
       }
@@ -128,8 +151,9 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
         if let prev = prevById[id] {
           if !prev.markerEquals(next) {
             if self.markerBuilder.hasIconTask(id) {
+              let buildToken = self.nextMarkerBuildToken(id)
               self.markerBuilder.buildIconAsync(next) { [weak self] icon in
-                guard let self else { return }
+                guard let self, self.isCurrentMarkerBuild(id, buildToken) else { return }
                 let marker = self.markerBuilder.build(next, icon: icon)
                 self.impl.addMarker(id: id, marker: marker)
               }
@@ -138,11 +162,23 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
                 guard let self else { return }
                 self.markerBuilder.update(prev, next, m)
               }
+
+              if !prev.markerStyleEquals(next) {
+                let buildToken = self.nextMarkerBuildToken(id)
+                self.markerBuilder.buildIconAsync(next) { [weak self] icon in
+                  guard let self else { return }
+                  self.impl.updateMarker(id: id) { marker in
+                    guard self.isCurrentMarkerBuild(id, buildToken) else { return }
+                    self.markerBuilder.updateIcon(marker, icon: icon)
+                  }
+                }
+              }
             }
           }
         } else {
+          let buildToken = self.nextMarkerBuildToken(id)
           self.markerBuilder.buildIconAsync(next) { [weak self] icon in
-            guard let self else { return }
+            guard let self, self.isCurrentMarkerBuild(id, buildToken) else { return }
             let marker = self.markerBuilder.build(next, icon: icon)
             self.impl.addMarker(id: id, marker: marker)
           }


### PR DESCRIPTION
## Pull request

Please ensure this PR targets the **`dev` branch** and follows the project conventions.
CI already runs linting, formatting, and build checks automatically.

---

### Before submitting

- [x] This PR targets the `dev` branch (not `main`)
- [x] Commit messages follow the semantic-release format
- [x] No debug logs or sensitive data included

---

### Summary

Prevent stale, duplicated, and ghost markers caused by asynchronous SVG icon rendering racing with marker updates, removal, recreation, and map initialization.

Marker rendering now uses three coordinated safeguards:

- Each render receives a unique identity token, and its result is applied only while that token is still current.
- Pending markers are keyed by marker ID and keep the latest marker properties together with the current rendered icon until the map is ready.
- Per-marker Android jobs and iOS tasks replace their predecessors atomically and remove themselves from the registry only when they are still the active operation.

When rendering completes for an existing marker, only its icon is updated. This avoids replaying non-icon state and unnecessarily closing or reopening its info window.

---

### Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Internal / CI
- [ ] Documentation

---

### Scope

- [x] Android
- [x] iOS
- [ ] JS
- [ ] Example App
- [ ] Docs

---

### Related

N/A

---

### Additional notes

- Starting a newer render atomically invalidates and cancels the previous operation for that marker.
- Cached-icon and no-icon paths use the same tracked lifecycle as asynchronous SVG rendering.
- Removing a marker invalidates its token, cancels its active render, and removes any pending marker state.
- Updates received before the map is ready are upserted, so only the latest state is materialized.
- Recreating a marker with the same ID cannot apply a result from an older render.
- Non-icon marker properties continue to update independently of asynchronous icon rendering.
- This change does not modify the JavaScript API or the example app.