### PR TITLE
fix: prevent marker callout flicker and inconsistent toggling

### DIFF
--- a/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
+++ b/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
@@ -551,8 +551,16 @@ class GoogleMapsViewImpl(
     val marker = markersById[id] ?: return@onUi
     block(marker)
     if (refreshInfoWindow && marker.isInfoWindowShown) {
-      marker.hideInfoWindow()
-      marker.showInfoWindow()
+      val hasInfoWindowContent =
+        marker.tagData.iconSvg != null ||
+          !marker.title.isNullOrEmpty() ||
+          !marker.snippet.isNullOrEmpty()
+
+      if (hasInfoWindowContent) {
+        marker.showInfoWindow()
+      } else {
+        marker.hideInfoWindow()
+      }
     }
   }
 

--- a/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
+++ b/android/src/main/java/com/rngooglemapsplus/GoogleMapsViewImpl.kt
@@ -545,11 +545,12 @@ class GoogleMapsViewImpl(
 
   fun updateMarker(
     id: String,
+    refreshInfoWindow: Boolean,
     block: (Marker) -> Unit,
   ) = onUi {
     val marker = markersById[id] ?: return@onUi
     block(marker)
-    if (marker.isInfoWindowShown) {
+    if (refreshInfoWindow && marker.isInfoWindowShown) {
       marker.hideInfoWindow()
       marker.showInfoWindow()
     }

--- a/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
+++ b/android/src/main/java/com/rngooglemapsplus/RNGoogleMapsPlusView.kt
@@ -7,6 +7,7 @@ import com.google.android.gms.maps.GoogleMapOptions
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.margelo.nitro.core.Promise
 import com.rngooglemapsplus.extensions.circleEquals
+import com.rngooglemapsplus.extensions.infoWindowContentEquals
 import com.rngooglemapsplus.extensions.isFileResult
 import com.rngooglemapsplus.extensions.markerEquals
 import com.rngooglemapsplus.extensions.polygonEquals
@@ -179,7 +180,10 @@ class RNGoogleMapsPlusView(
                 )
               }
             } else {
-              view.updateMarker(id) { marker ->
+              view.updateMarker(
+                id,
+                refreshInfoWindow = !prev.infoWindowContentEquals(next),
+              ) { marker ->
                 markerBuilder.update(prev, next, marker)
               }
             }

--- a/android/src/main/java/com/rngooglemapsplus/extensions/RNMarkerExtension.kt
+++ b/android/src/main/java/com/rngooglemapsplus/extensions/RNMarkerExtension.kt
@@ -46,6 +46,12 @@ fun RNMarker.markerInfoWindowStyleEquals(b: RNMarker): Boolean {
   return true
 }
 
+fun RNMarker.infoWindowContentEquals(b: RNMarker): Boolean {
+  if (title != b.title) return false
+  if (snippet != b.snippet) return false
+  return markerInfoWindowStyleEquals(b)
+}
+
 fun RNMarker.markerStyleEquals(b: RNMarker): Boolean {
   if (iconSvg?.width != b.iconSvg?.width) return false
   if (iconSvg?.height != b.iconSvg?.height) return false

--- a/android/src/main/java/com/rngooglemapsplus/extensions/RNMarkerExtension.kt
+++ b/android/src/main/java/com/rngooglemapsplus/extensions/RNMarkerExtension.kt
@@ -47,9 +47,12 @@ fun RNMarker.markerInfoWindowStyleEquals(b: RNMarker): Boolean {
 }
 
 fun RNMarker.infoWindowContentEquals(b: RNMarker): Boolean {
+  if (infoWindowIconSvg != null && b.infoWindowIconSvg != null) {
+    return markerInfoWindowStyleEquals(b)
+  }
+  if (infoWindowIconSvg != null || b.infoWindowIconSvg != null) return false
   if (title != b.title) return false
-  if (snippet != b.snippet) return false
-  return markerInfoWindowStyleEquals(b)
+  return snippet == b.snippet
 }
 
 fun RNMarker.markerStyleEquals(b: RNMarker): Boolean {

--- a/example/src/screens/MarkersScreen.tsx
+++ b/example/src/screens/MarkersScreen.tsx
@@ -117,6 +117,15 @@ export default function MarkersScreen() {
     openMarkerIdRef.current = null;
   }, []);
 
+  const handleMarkerSave = useCallback((marker: RNMarker) => {
+    const openMarkerId = openMarkerIdRef.current;
+    if (openMarkerId !== null) {
+      mapRef.current?.hideMarkerInfoWindow(openMarkerId);
+    }
+    openMarkerIdRef.current = null;
+    setMarkers([marker]);
+  }, []);
+
   return (
     <>
       <MapWrapper
@@ -134,7 +143,7 @@ export default function MarkersScreen() {
         initialData={markers ? markers[0]! : makeMarker(1)}
         validator={RNMarkerValidator}
         onClose={() => setDialogVisible(false)}
-        onSave={(c) => setMarkers([c])}
+        onSave={handleMarkerSave}
       />
     </>
   );

--- a/example/src/screens/MarkersScreen.tsx
+++ b/example/src/screens/MarkersScreen.tsx
@@ -52,6 +52,7 @@ export default function MarkersScreen() {
   const [markers, setMarkers] = useState<RNMarker[] | undefined>(undefined);
   const [dialogVisible, setDialogVisible] = useState(true);
   const animatingRef = useRef(false);
+  const openMarkerIdRef = useRef<string | null>(null);
   const uiSettings: RNMapUiSettings = useMemo(
     () => ({
       allGesturesEnabled: true,
@@ -102,7 +103,18 @@ export default function MarkersScreen() {
   );
 
   const handleMarkerPress = useCallback((id: string) => {
+    if (openMarkerIdRef.current === id) {
+      mapRef.current?.hideMarkerInfoWindow(id);
+      openMarkerIdRef.current = null;
+      return;
+    }
+
     mapRef.current?.showMarkerInfoWindow(id);
+    openMarkerIdRef.current = id;
+  }, []);
+
+  const handleMapPress = useCallback(() => {
+    openMarkerIdRef.current = null;
   }, []);
 
   return (
@@ -112,6 +124,7 @@ export default function MarkersScreen() {
         uiSettings={uiSettings}
         markers={markers ? markers : []}
         onMarkerPress={handleMarkerPress}
+        onMapPress={handleMapPress}
       >
         <ControlPanel viewRef={mapRef} buttons={buttons} />
       </MapWrapper>

--- a/ios/GoogleMapViewImpl.swift
+++ b/ios/GoogleMapViewImpl.swift
@@ -25,6 +25,7 @@ GMSIndoorDisplayDelegate {
     [(id: String, urlTileOverlay: GMSURLTileLayer)] = []
 
   private var markersById: [String: GMSMarker] = [:]
+  private var markerRefreshingInfoWindow: GMSMarker?
   private var polylinesById: [String: GMSPolyline] = [:]
   private var polygonsById: [String: GMSPolygon] = [:]
   private var circlesById: [String: GMSCircle] = [:]
@@ -503,19 +504,36 @@ GMSIndoorDisplayDelegate {
   func updateMarker(
     id: String,
     refreshInfoWindow: Bool,
+    recreateInfoWindow: Bool,
     block: @escaping (GMSMarker) -> Void
   ) {
     onMain {
       self.markersById[id].map {
+        let hadInfoWindowContent = self.hasInfoWindowContent($0)
         block($0)
         if refreshInfoWindow,
            let mapView = self.mapView,
            mapView.selectedMarker == $0 {
-          mapView.selectedMarker = nil
-          mapView.selectedMarker = $0
+          if !self.hasInfoWindowContent($0) {
+            mapView.selectedMarker = nil
+          } else if recreateInfoWindow || !hadInfoWindowContent {
+            self.markerRefreshingInfoWindow = $0
+            mapView.selectedMarker = nil
+            self.markerRefreshingInfoWindow = nil
+            mapView.selectedMarker = $0
+          } else {
+            $0.tracksInfoWindowChanges = true
+            $0.tracksInfoWindowChanges = false
+          }
         }
       }
     }
+  }
+
+  private func hasInfoWindowContent(_ marker: GMSMarker) -> Bool {
+    if marker.tagData.iconSvg != nil { return true }
+    if !(marker.title?.isEmpty ?? true) { return true }
+    return !(marker.snippet?.isEmpty ?? true)
   }
 
   func removeMarker(id: String) {
@@ -995,6 +1013,10 @@ GMSIndoorDisplayDelegate {
 
   func mapView(_ mapView: GMSMapView, didCloseInfoWindowOf marker: GMSMarker) {
     onMain {
+      if self.markerRefreshingInfoWindow === marker {
+        return
+      }
+
       self.onInfoWindowClose?(marker.idTag)
     }
   }

--- a/ios/GoogleMapViewImpl.swift
+++ b/ios/GoogleMapViewImpl.swift
@@ -500,11 +500,17 @@ GMSIndoorDisplayDelegate {
     }
   }
 
-  func updateMarker(id: String, block: @escaping (GMSMarker) -> Void) {
+  func updateMarker(
+    id: String,
+    refreshInfoWindow: Bool,
+    block: @escaping (GMSMarker) -> Void
+  ) {
     onMain {
       self.markersById[id].map {
         block($0)
-        if let mapView = self.mapView, mapView.selectedMarker == $0 {
+        if refreshInfoWindow,
+           let mapView = self.mapView,
+           mapView.selectedMarker == $0 {
           mapView.selectedMarker = nil
           mapView.selectedMarker = $0
         }

--- a/ios/MapMarkerBuilder.swift
+++ b/ios/MapMarkerBuilder.swift
@@ -55,7 +55,6 @@ final class MapMarkerBuilder {
       withCATransaction(disableActions: true) {
 
         var tracksViewChanges = false
-        var tracksInfoWindowChanges = false
 
         if !prev.coordinateEquals(next) {
           m.position = next.coordinate.toCLLocationCoordinate2D()
@@ -97,12 +96,10 @@ final class MapMarkerBuilder {
         }
 
         if prev.title != next.title {
-          tracksInfoWindowChanges = true
           m.title = next.title
         }
 
         if prev.snippet != next.snippet {
-          tracksInfoWindowChanges = true
           m.snippet = next.snippet
         }
 
@@ -137,19 +134,7 @@ final class MapMarkerBuilder {
 
         if tracksViewChanges {
           m.tracksViewChanges = tracksViewChanges
-        }
-        if tracksInfoWindowChanges {
-          m.tracksInfoWindowChanges = tracksInfoWindowChanges
-        }
-
-        if tracksViewChanges || tracksInfoWindowChanges {
-          if tracksViewChanges {
-            m.tracksViewChanges = false
-          }
-
-          if tracksInfoWindowChanges {
-            m.tracksInfoWindowChanges = false
-          }
+          m.tracksViewChanges = false
         }
       }
     }

--- a/ios/RNGoogleMapsPlusView.swift
+++ b/ios/RNGoogleMapsPlusView.swift
@@ -134,7 +134,10 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
                 self.impl.addMarker(id: id, marker: marker)
               }
             } else {
-              self.impl.updateMarker(id: id) { [weak self] m in
+              self.impl.updateMarker(
+                id: id,
+                refreshInfoWindow: !prev.infoWindowContentEquals(next)
+              ) { [weak self] m in
                 guard let self else { return }
                 self.markerBuilder.update(prev, next, m)
               }

--- a/ios/RNGoogleMapsPlusView.swift
+++ b/ios/RNGoogleMapsPlusView.swift
@@ -136,7 +136,8 @@ final class RNGoogleMapsPlusView: HybridRNGoogleMapsPlusViewSpec {
             } else {
               self.impl.updateMarker(
                 id: id,
-                refreshInfoWindow: !prev.infoWindowContentEquals(next)
+                refreshInfoWindow: !prev.infoWindowContentEquals(next),
+                recreateInfoWindow: !prev.markerInfoWindowStyleEquals(next)
               ) { [weak self] m in
                 guard let self else { return }
                 self.markerBuilder.update(prev, next, m)

--- a/ios/extensions/RNMarker+Extension.swift
+++ b/ios/extensions/RNMarker+Extension.swift
@@ -43,6 +43,12 @@ extension RNMarker {
     return true
   }
 
+  func infoWindowContentEquals(_ b: RNMarker) -> Bool {
+    if title != b.title { return false }
+    if snippet != b.snippet { return false }
+    return markerInfoWindowStyleEquals(b)
+  }
+
   func markerStyleEquals(_ b: RNMarker) -> Bool {
     if iconSvg?.width != b.iconSvg?.width { return false }
     if iconSvg?.height != b.iconSvg?.height { return false }

--- a/ios/extensions/RNMarker+Extension.swift
+++ b/ios/extensions/RNMarker+Extension.swift
@@ -44,9 +44,14 @@ extension RNMarker {
   }
 
   func infoWindowContentEquals(_ b: RNMarker) -> Bool {
+    let usesCustomInfoWindow = infoWindowIconSvg != nil
+    let bUsesCustomInfoWindow = b.infoWindowIconSvg != nil
+
+    if usesCustomInfoWindow != bUsesCustomInfoWindow { return false }
+    if usesCustomInfoWindow { return markerInfoWindowStyleEquals(b) }
     if title != b.title { return false }
     if snippet != b.snippet { return false }
-    return markerInfoWindowStyleEquals(b)
+    return true
   }
 
   func markerStyleEquals(_ b: RNMarker) -> Bool {


### PR DESCRIPTION
## Pull request

Please ensure this PR targets the **`dev` branch** and follows the project conventions.
CI already runs linting, formatting, and build checks automatically.

---

### Before submitting

- [x] This PR targets the `dev` branch (not `main`)
- [x] Commit messages follow the semantic-release format
- [x] No debug logs or sensitive data included

---

### Summary

Prevents marker callouts from flickering or emitting spurious close events while markers are updated.

Coordinate-only marker updates no longer refresh an open callout. Callouts are refreshed only when their visible content changes:

- Android refreshes an existing callout without an unnecessary hide/show cycle.
- iOS redraws default callout content in place and recreates custom callouts only when their SVG or display mode changes.
- Removing all callout content closes the currently visible callout normally.
- Custom callouts ignore changes to hidden title and snippet fields.

The Markers example tracks the logical open callout in its TypeScript handler. Repeated marker presses toggle it consistently across Android and iOS, while map presses and marker saves reset the state safely.

---

### Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Internal / CI
- [ ] Documentation

---

### Scope

- [x] Android
- [x] iOS
- [x] JS
- [x] Example App
- [ ] Docs

---

### Related

N/A

---

### Additional notes

Google Maps SDK for Android closes the currently visible info window before invoking the marker click callback. The example therefore treats its marker reference as logical toggle state instead of deriving it from `onInfoWindowClose`.

No generated build files, manifest changes, lockfile churn, debug logs, or sensitive data are included.