### PR TITLE
fix(ios): robust post_install injection — resolve svgkit_patch via node & anchor with mergeContents

### DIFF
--- a/expoConfig/src/ios/withIosGoogleMapsPlus.ts
+++ b/expoConfig/src/ios/withIosGoogleMapsPlus.ts
@@ -40,19 +40,24 @@ const withIosGoogleMapsPlus: ConfigPlugin<RNGoogleMapsPlusExpoPluginProps> = (
       }).contents;
     }
 
-    const podFilePatch = `
-  require_relative '../node_modules/react-native-google-maps-plus/scripts/svgkit_patch'
-  apply_svgkit_patch(installer)
-  `;
+    // Resolve svgkit_patch.rb via Node at pod-install time (mirrors how the RN/Expo Podfile
+    // resolves its own scripts). Robust to monorepos where node_modules is hoisted to a workspace
+    // root — the old hardcoded '../node_modules/...' path only resolved for non-hoisted layouts.
+    const podFilePatch = `  require File.join(File.dirname(\`node --print "require.resolve('react-native-google-maps-plus/package.json')"\`), 'scripts', 'svgkit_patch')\n  apply_svgkit_patch(installer)`;
 
     if (src.includes('post_install do |installer|')) {
-      src = src.replace(
-        /post_install do \|installer\|([\s\S]*?)end/,
-        (match, inner) => {
-          if (inner.includes('SVGKit Patch')) return match; // idempotent
-          return `post_install do |installer|${inner}\n${podFilePatch}\nend`;
-        }
-      );
+      // Anchor on the post_install line via mergeContents instead of a non-greedy
+      // /post_install ... ([\s\S]*?) end/ regex. The old regex stopped at the FIRST `end`, so when
+      // another config plugin had already injected post_install content with a nested `if ... end`
+      // block, apply_svgkit_patch was placed inside that block and never applied.
+      src = mergeContents({
+        tag: 'react-native-google-maps-svgkit-patch',
+        src,
+        newSrc: podFilePatch,
+        anchor: /post_install do \|installer\|/,
+        offset: 1,
+        comment: '#',
+      }).contents;
     } else {
       src += `\npost_install do |installer|\n${podFilePatch}\nend\n`;
     }


### PR DESCRIPTION
## Summary

The iOS config plugin's `post_install` injection has two issues in real projects:

**1. Monorepo path.** It injects `require_relative '../node_modules/react-native-google-maps-plus/scripts/svgkit_patch'`. In a Yarn/npm workspace, `node_modules` is hoisted to the workspace root, so from `<app>/ios/Podfile` the package lives at `../../node_modules` — `pod install` can't find `svgkit_patch`, the SVGKit patch never runs, and the iOS build fails (SVGKit ends up importing Reanimated's `CSSValue.h`, e.g. `'reanimated/CSS/misc/ViewStylesRepository.h' file not found`).

**2. post_install collision.** Injection used `src.replace(/post_install do \|installer\|([\s\S]*?)end/, …)`. The non-greedy `[\s\S]*?end` matches only the **first** `end`. If another config plugin (e.g. `@iterable/expo-plugin`'s fmt workaround, which adds `installer.pods_project.targets.each { … if target.name == 'fmt' … end … }`) has already injected into `post_install`, `apply_svgkit_patch(installer)` lands **inside** that `if` block and never runs — producing malformed Ruby depending on plugin order.

## Fix

1. Resolve `svgkit_patch.rb` via `node --print "require.resolve(...)"` at pod-install time — the same pattern the RN/Expo Podfile header already uses for its own scripts. Robust to hoisting, no hardcoded relative path.
2. Inject via `mergeContents` anchored on the `post_install do |installer|` line (already used in this file for `use_modular_headers!`) instead of the fragile regex — well-formed and order-independent regardless of what other plugins added.

## Testing

Verified on a Yarn-workspaces Expo SDK 56 app (RN 0.85, New Arch) that also uses `@iterable/expo-plugin`: after this change, `expo prebuild` produces a well-formed `post_install` with `apply_svgkit_patch` at top level, `pod install` resolves the script under the hoisted `node_modules`, and the iOS build compiles SVGKit correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
