### PR TITLE
fix(android): use LocationCompat for mock locations

### DIFF
--- a/android/src/main/java/com/rngooglemapsplus/extensions/LocationExtension.kt
+++ b/android/src/main/java/com/rngooglemapsplus/extensions/LocationExtension.kt
@@ -2,6 +2,7 @@ package com.rngooglemapsplus.extensions
 
 import android.location.Location
 import android.os.Build
+import androidx.core.location.LocationCompat
 import com.rngooglemapsplus.RNLatLng
 import com.rngooglemapsplus.RNLocation
 import com.rngooglemapsplus.RNLocationAndroid
@@ -88,11 +89,7 @@ fun Location.toRNLocation(): RNLocation =
               }
             }
           },
-        isMock =
-          when {
-            Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> isMock
-            else -> isFromMockProvider
-          },
+        isMock = LocationCompat.isMock(this),
       ),
     ios = null,
   )


### PR DESCRIPTION
## Pull request

This PR targets the **`dev` branch** and follows the project conventions.

---

### Before submitting

- [x] This PR targets the `dev` branch (not `main`)
- [x] Commit messages follow the semantic-release format
- [x] No debug logs or sensitive data included

---

### Summary

Replace the manual Android SDK version check for mock locations with `LocationCompat.isMock()`.

This avoids directly using the deprecated `Location.isFromMockProvider()` API while preserving compatibility across supported Android versions.

---

### Type of change

- [ ] Feature
- [x] Fix
- [ ] Refactor
- [ ] Internal / CI
- [ ] Documentation

---

### Scope

- [x] Android
- [ ] iOS
- [ ] JS
- [ ] Example App
- [ ] Docs

---

### Related

None.

---

### Additional notes

None.