### PR TITLE
docs: document Android dark mode requirements

### DIFF
--- a/src/RNGoogleMapsPlusView.nitro.ts
+++ b/src/RNGoogleMapsPlusView.nitro.ts
@@ -80,7 +80,13 @@ export interface RNGoogleMapsPlusViewProps extends HybridViewProps {
    */
   customMapStyle?: string;
 
-  /** Overrides OS UI mode. See {@link RNUserInterfaceStyle}. */
+  /**
+   * Overrides OS UI mode. See {@link RNUserInterfaceStyle}.
+   *
+   * @remarks On Android, dark mode requires the latest Google Maps renderer and
+   * is not supported in `liteMode`. Devices or emulators with missing or
+   * outdated Google Play services may fall back to the legacy renderer.
+   */
   userInterfaceStyle?: RNUserInterfaceStyle;
 
   /** Zoom range. See {@link RNMapZoomConfig}. */


### PR DESCRIPTION
## Pull request

Please ensure this PR targets the **`dev` branch** and follows the project conventions.
CI already runs linting, formatting, and build checks automatically.

---

### Before submitting

- [x] This PR targets the `dev` branch (not `main`)
- [x] Commit messages follow the semantic-release format
- [x] No debug logs or sensitive data included

---

### Summary

Documents the Android requirements and limitations of the `userInterfaceStyle` prop.

The API reference now clarifies that dark mode:

- requires the latest Google Maps renderer;
- is not supported in `liteMode`;
- may be unavailable when missing or outdated Google Play services cause a fallback to the legacy renderer.

---

### Type of change

- [ ] Feature
- [ ] Fix
- [ ] Refactor
- [ ] Internal / CI
- [x] Documentation

---

### Scope

- [ ] Android
- [ ] iOS
- [ ] JS
- [ ] Example App
- [x] Docs

---

### Related

Refs [Discussion #123](https://github.com/pinpong/react-native-google-maps-plus/discussions/123)

---

### Additional notes

This PR only updates the generated API documentation source. It does not change runtime behavior.